### PR TITLE
Exit non-zero on updatedb error.

### DIFF
--- a/cmd/updatedb.go
+++ b/cmd/updatedb.go
@@ -22,6 +22,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 
 	"github.com/servian/TechChallengeApp/db"
 	"github.com/spf13/cobra"
@@ -37,6 +39,7 @@ var updatedbCmd = &cobra.Command{
 
 		if err != nil {
 			fmt.Println(err)
+			os.Exit(1)
 		}
 	},
 }


### PR DESCRIPTION
### Description

When an error occurs during the updatedb command it would fail without setting the exit code. This changes it to return '1' in the event of an error,

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added issue number to `Fixes` line above
