### PR TITLE
duplicate the healthcheck handler

### DIFF
--- a/ui/ui.go
+++ b/ui/ui.go
@@ -45,6 +45,7 @@ func Start(cfg Config, listener net.Listener) {
 	}
 
 	mainRouter := mux.NewRouter()
+	mainRouter.Handle("/healthcheck", healthcheckHandler(cfg))
 	mainRouter.Handle("/healthcheck/", healthcheckHandler(cfg))
 
 	apiRouter := mainRouter.PathPrefix("/api").Subrouter()


### PR DESCRIPTION
### Description

The health-check URI currently expects a trailing slash, this PR adds a second entry in the handler to accept it without the trailing slash because its common to forget to add one.

### Checklist

- [x] Code compiles correctly
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README / documentation, if necessary
- [x] Added issue number to `Fixes` line above
